### PR TITLE
Change the base of the Create action of RepositoriesController to Redmine 3.4

### DIFF
--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -5,6 +5,7 @@ class Repository::Github < Repository::Git
 
     before_save :set_local_url
     before_save :register_hook
+    safe_attributes 'register_hook'
 
     def self.human_attribute_name(attribute, *args)
         attribute_name = attribute.to_s
@@ -39,6 +40,10 @@ class Repository::Github < Repository::Git
             end
         end
         extra_boolean_attribute('extra_register_hook')
+    end
+
+    def register_hook=(arg)
+        merge_extra_info "extra_register_hook" => arg
     end
 
     def extra_hook_registered

--- a/lib/scm_repositories_helper_patch.rb
+++ b/lib/scm_repositories_helper_patch.rb
@@ -12,7 +12,7 @@ module ScmRepositoriesHelperPatch
             alias_method_chain :mercurial_field_tags,  :add
             alias_method_chain :git_field_tags,        :add
             alias_method_chain :bazaar_field_tags,     :add
-            
+
             alias_method_chain :scm_path_info_tag, :external if method_defined?(:scm_path_info_tag)
         end
     end
@@ -187,7 +187,7 @@ module ScmRepositoriesHelperPatch
                                                                           :onchange => "this.name='repository[password]';") +
                                            content_tag('em', l(:text_github_credentials_note), :class => 'info'))
             if !Setting.autofetch_changesets? && GithubCreator.can_register_hook?
-                githubtags << content_tag('p', form.check_box(:extra_register_hook, :disabled => repository.extra_hook_registered) + ' ' +
+                githubtags << content_tag('p', form.check_box(:register_hook, :disabled => repository.extra_hook_registered) + ' ' +
                                                l(:text_github_register_hook_note))
             end
 


### PR DESCRIPTION
changes
+ Stop using to pickup_extra_info method
+ Rename extra_register_hook to register_hook
+ Delete duplicate code in build_new_repository_from_params method

scm-creator内で利用しているpickup_extra_infoメソッドがRedmine3.4時点では削除されていたのですが、SCMCreatorには残ったままとなっていたため、エラーの原因になっていました。
それを改善するため、RepositoriesControllerのcreateアクションをRedmine3.4を元にして書き直す変更を行いました。