### PR TITLE
Fix a bug in Github's fetch_changesets

### DIFF
--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -103,15 +103,18 @@ protected
     end
 
     def clone_repository
-        if File.directory?(GithubCreator.options['path'])
+        unless File.directory?(GithubCreator.options['path'])
             path = File.dirname(root_url)
             Dir.mkdir(path) unless File.directory?(path)
             Rails.logger.info "Cloning #{url} to #{root_url}"
             unless scm.clone
                 errors.add(:base, :scm_repository_cloning_failed)
+                false
             end
         else
+            Rails.logger.warn "Can't find directory: #{GithubCreator.options['path']} ( path for #{scm_name} )"
             errors.add(:base, :scm_repository_cloning_failed)
+            false
         end
     end
 end

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -103,7 +103,7 @@ protected
     end
 
     def clone_repository
-        unless File.directory?(GithubCreator.options['path'])
+        if File.directory?(GithubCreator.options['path'])
             path = File.dirname(root_url)
             Dir.mkdir(path) unless File.directory?(path)
             Rails.logger.info "Cloning #{url} to #{root_url}"

--- a/app/models/repository/github.rb
+++ b/app/models/repository/github.rb
@@ -62,19 +62,6 @@ class Repository::Github < Repository::Git
         super
     end
 
-    def clone_repository
-      if File.directory?(GithubCreator.options['path'])
-        path = File.dirname(root_url)
-        Dir.mkdir(path) unless File.directory?(path)
-        Rails.logger.info "Cloning #{url} to #{root_url}"
-        unless scm.clone
-          errors.add(:base, :scm_repository_cloning_failed)
-        end
-      else
-        errors.add(:base, :scm_repository_cloning_failed)
-      end
-    end
-
     def clear_extra_info_of_changesets
     end
 
@@ -115,4 +102,16 @@ protected
         end
     end
 
+    def clone_repository
+        if File.directory?(GithubCreator.options['path'])
+            path = File.dirname(root_url)
+            Dir.mkdir(path) unless File.directory?(path)
+            Rails.logger.info "Cloning #{url} to #{root_url}"
+            unless scm.clone
+                errors.add(:base, :scm_repository_cloning_failed)
+            end
+        else
+            errors.add(:base, :scm_repository_cloning_failed)
+        end
+    end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,3 +30,4 @@ en:
         scm_local_repositories_denied: Adding local repositories was denied by administrator
         scm_only_creator: Use "Create new repository" button to create/add a repository
         scm_repository_creation_failed: Repository creation failed
+        scm_repository_cloning_failed: Repository cloning failed

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,3 +22,4 @@ ja:
         scm_local_repositories_denied: ローカルリポジトリの追加は管理者によって拒否されました。
         scm_only_creator: リポジトリの作成/追加には「リポジトリの作成」ボタンを使用します。
         scm_repository_creation_failed: リポジトリ作成に失敗しました。
+        scm_repository_cloning_failed: リポジトリのcloneに失敗しました。

--- a/lib/adapters/github_adapter.rb
+++ b/lib/adapters/github_adapter.rb
@@ -12,6 +12,13 @@ module Redmine
                     git_cmd(cmd_args)
                 rescue ScmCommandAborted => error
                     Rails.logger.error "Github repository cloning failed: #{error.message}"
+                    false
+                else
+                    if File.directory?(root_url)
+                        true
+                    else
+                        false
+                    end
                 end
 
                 def fetch

--- a/lib/adapters/github_adapter.rb
+++ b/lib/adapters/github_adapter.rb
@@ -10,15 +10,10 @@ module Redmine
                     cmd_args << url_with_credentials
                     cmd_args << root_url
                     git_cmd(cmd_args)
+                    true
                 rescue ScmCommandAborted => error
                     Rails.logger.error "Github repository cloning failed: #{error.message}"
                     false
-                else
-                    if File.directory?(root_url)
-                        true
-                    else
-                        false
-                    end
                 end
 
                 def fetch

--- a/lib/creator/github_creator.rb
+++ b/lib/creator/github_creator.rb
@@ -97,9 +97,9 @@ class GithubCreator < SCMCreator
             if response.is_a?(Sawyer::Resource) && response.key?(:clone_url)
                 repository.merge_extra_info('extra_created_with_scm' => 1)
                 if repository && repository.url =~ %r{\Agit@} && repository.login.blank? && response.key?(:ssh_url)
-                    url = response[:ssh_url]
+                    response[:ssh_url]
                 else
-                    url = response[:clone_url]
+                    response[:clone_url]
                 end
             else
                 false
@@ -107,15 +107,6 @@ class GithubCreator < SCMCreator
         rescue Octokit::Error => error
             Rails.logger.error error.message
             false
-        else
-            repository.url = url
-            repository.root_url = repository.local_url
-            path = File.dirname(repository.root_url)
-            Dir.mkdir(path) unless File.directory?(path)
-            Rails.logger.info "Cloning #{repository.url} to #{repository.root_url}"
-            repository.scm.clone
-        ensure
-            return url
         end
 
         def can_register_hook?

--- a/lib/creator/github_creator.rb
+++ b/lib/creator/github_creator.rb
@@ -97,9 +97,9 @@ class GithubCreator < SCMCreator
             if response.is_a?(Sawyer::Resource) && response.key?(:clone_url)
                 repository.merge_extra_info('extra_created_with_scm' => 1)
                 if repository && repository.url =~ %r{\Agit@} && repository.login.blank? && response.key?(:ssh_url)
-                    response[:ssh_url]
+                    url = response[:ssh_url]
                 else
-                    response[:clone_url]
+                    url = response[:clone_url]
                 end
             else
                 false
@@ -107,6 +107,15 @@ class GithubCreator < SCMCreator
         rescue Octokit::Error => error
             Rails.logger.error error.message
             false
+        else
+            repository.url = url
+            repository.root_url = repository.local_url
+            path = File.dirname(repository.root_url)
+            Dir.mkdir(path) unless File.directory?(path)
+            Rails.logger.info "Cloning #{repository.url} to #{repository.root_url}"
+            repository.scm.clone
+        ensure
+            return url
         end
 
         def can_register_hook?


### PR DESCRIPTION
There was a bug that could not fetch repository when cloned repository without branches.

change points
* fixed the bug.
* Change repository clone timing from Repository::Github#fetch_changesets to before create repository