### PR TITLE
Enable ScmRepositoryPatch

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -29,6 +29,9 @@ Rails.configuration.to_prepare do
     unless RepositoriesController.included_modules.include?(ScmRepositoriesControllerPatch)
         RepositoriesController.send(:include, ScmRepositoriesControllerPatch)
     end
+    unless Repository.included_modules.include?(ScmRepositoryPatch)
+        Repository.send(:include, ScmRepositoryPatch)
+    end
 end
 
 Redmine::Plugin.register :redmine_scm do


### PR DESCRIPTION
Until now, because the ScmRepositoryPatch was not included, the repository file deletion function could not be used.

I Added processing to include ScmRepositoryPatch.
This change will allow you to delete the repository file.