### PR TITLE
Change processing when failure to delete repository on file system fails

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
   text_scm_repository_destroy_confirmation: Do you want to remove the repository from the file system as well?
 
   warning_github_hook_registration_failed: Github service hook registration failed.
+  warning_repository_deletion_failed: Repository deletion failed.
 
   activerecord:
     errors:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,8 @@ ja:
   text_scm_repository_created_by_scm: ファイルシステム上のリポジトリはRedmineで使用するために作成しました。Redmineエントリの削除により、作成したリポジトリが使われない状態にになるかもしれません。
   text_scm_repository_destroy_confirmation: ファイルシステムから同様にリポジトリを削除しますか？
 
+  warning_repository_deletion_failed: リポジトリの削除に失敗しました。
+
   activerecord:
     errors:
       messages:

--- a/lib/creator/scm_creator.rb
+++ b/lib/creator/scm_creator.rb
@@ -132,7 +132,11 @@ class SCMCreator
         # removes repository
         def delete_repository(path)
             # See: http://www.ruby-doc.org/stdlib-1.9.3/libdoc/fileutils/rdoc/FileUtils.html#method-c-remove_entry_secure
-            FileUtils.remove_entry_secure(path, true)
+            FileUtils.remove_entry_secure(path, false)
+            true
+        rescue => error
+            Rails.logger.error "Failed to delete repository on file system: #{error.message}"
+            false
         end
 
         # executes custom scripts

--- a/lib/scm_repositories_controller_patch.rb
+++ b/lib/scm_repositories_controller_patch.rb
@@ -80,6 +80,12 @@ module ScmRepositoriesControllerPatch
             end
         end
 
+        # Original function
+        #def destroy
+        #  @repository.destroy if request.delete?
+        #  redirect_to settings_project_path(@project, :tab => 'repositories')
+        #end
+
         def destroy_with_confirmation
             if @repository.created_with_scm
                 if params[:confirm]
@@ -87,7 +93,12 @@ module ScmRepositoriesControllerPatch
                         @repository.created_with_scm = false
                     end
 
-                    destroy_without_confirmation
+                    if request.delete?
+                        unless @repository.destroy
+                          flash[:warning] = l(:warning_repository_deletion_failed)
+                        end
+                    end
+                    redirect_to settings_project_path(@project, :tab => 'repositories')
                 end
             else
                 destroy_without_confirmation

--- a/lib/scm_repository_patch.rb
+++ b/lib/scm_repository_patch.rb
@@ -22,7 +22,7 @@ module ScmRepositoryPatch
                         path = interface.existing_path(name, self)
                         if path
                             interface.execute(ScmConfig['pre_delete'], path, project) if ScmConfig['pre_delete']
-                            interface.delete_repository(path)
+                            return false unless interface.delete_repository(path)
                             interface.execute(ScmConfig['post_delete'], path, project) if ScmConfig['post_delete']
                         end
                     end


### PR DESCRIPTION
When repository deletion on the file system fails,
Before change: successfully delete repository
After change: Failed to delete repository. Display an error message.