### PR TITLE
 Fix not to change protected attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The following explanation is adapted from a [Origin of fork](http://projects.and
 
 Simple [Subversion](http://subversion.apache.org/), [Git](https://git-scm.com/), [Mercurial](https://www.mercurial-scm.org/),[Bazaar](http://bazaar.canonical.com/en/) and [Github](https://github.com/) repository creation plugin for [Redmine](http://www.redmine.org/). With this plugin repository creation and registration becomes very easy and needs just one click (or even no click).
 
+This repository contains fixes to support Redmine3.4 in addition to the original code of the fork.
+
 This plugin requires __Redmine version 3.4.0__ or higher.
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ The following explanation is adapted from a [Origin of fork](http://projects.and
 
 Simple [Subversion](http://subversion.apache.org/), [Git](https://git-scm.com/), [Mercurial](https://www.mercurial-scm.org/),[Bazaar](http://bazaar.canonical.com/en/) and [Github](https://github.com/) repository creation plugin for [Redmine](http://www.redmine.org/). With this plugin repository creation and registration becomes very easy and needs just one click (or even no click).
 
-This repository contains fixes to support Redmine3.4 in addition to the original code of the fork.
+This repository is different from the original repository forked
+in the following point.
+* Change for use with Redmine 3.4
+* Bug fixese
 
 This plugin requires __Redmine version 3.4.0__ or higher.
 

--- a/lib/scm_repositories_controller_patch.rb
+++ b/lib/scm_repositories_controller_patch.rb
@@ -41,7 +41,7 @@ module ScmRepositoriesControllerPatch
                !ScmConfig['allow_add_local']
 
                 if params[:operation].present? && params[:operation] == 'add'
-                    @repository.attributes = interface.sanitize(@repository.attributes)
+                    @repository.safe_attributes = interface.sanitize(@repository.attributes)
                 end
 
                 if @repository.valid? && params[:operation].present? && params[:operation] == 'add'


### PR DESCRIPTION
Change to prevent warning "WARNING: Can't mass-assign protected attributes" from being output.