### PR TITLE
Allow git Repos in subdirs <project>/<repo>

### DIFF
--- a/config/scm.yml
+++ b/config/scm.yml
@@ -22,6 +22,7 @@ production:
     update_server_info: true
     git_ext: true
     append: trunk
+    in_subdir: false
   mercurial:
     path: /var/lib/mercurial
     hg: /usr/bin/hg

--- a/lib/creator/git_creator.rb
+++ b/lib/creator/git_creator.rb
@@ -48,7 +48,7 @@ class GitCreator < SCMCreator
 
         def repository_name(path)
             base = Redmine::Platform.mswin? ? options['path'].gsub(%r{\\}, "/") : options['path']
-            matches = Regexp.new("\\A#{Regexp.escape(base)}/([^/]+?)(\\.git)?/?\\z").match(path)
+            matches = Regexp.new("\\A#{Regexp.escape(base)}\/([a-z0-9\-_]+\/?[a-z0-9\-_]+)(\.git)?\\z").match(path)
             matches ? matches[1] : nil
         end
 

--- a/lib/creator/git_creator.rb
+++ b/lib/creator/git_creator.rb
@@ -49,7 +49,7 @@ class GitCreator < SCMCreator
         def repository_name(path)
             base = Redmine::Platform.mswin? ? options['path'].gsub(%r{\\}, "/") : options['path']
             if options['in_subdir']
-                matches = Regexp.new("\\A#{Regexp.escape(base)}\/([a-z0-9\-_]+\/?[a-z0-9\-_]+)(\.git)?\\z").match(path)
+                matches = Regexp.new("\\A#{Regexp.escape(base)}\/([^/]+?\/[^/]+?)(\.git)?\\z").match(path)
             else
 +               matches = Regexp.new("\\A#{Regexp.escape(base)}/([^/]+?)(\\.git)?/?\\z").match(path)
             end

--- a/lib/creator/git_creator.rb
+++ b/lib/creator/git_creator.rb
@@ -48,7 +48,12 @@ class GitCreator < SCMCreator
 
         def repository_name(path)
             base = Redmine::Platform.mswin? ? options['path'].gsub(%r{\\}, "/") : options['path']
-            matches = Regexp.new("\\A#{Regexp.escape(base)}\/([a-z0-9\-_]+\/?[a-z0-9\-_]+)(\.git)?\\z").match(path)
+            if options['in_subdir']
+                matches = Regexp.new("\\A#{Regexp.escape(base)}\/([a-z0-9\-_]+\/?[a-z0-9\-_]+)(\.git)?\\z").match(path)
+            else
++               matches = Regexp.new("\\A#{Regexp.escape(base)}/([^/]+?)(\\.git)?/?\\z").match(path)
+            end
+            
             matches ? matches[1] : nil
         end
 

--- a/lib/scm_repositories_helper_patch.rb
+++ b/lib/scm_repositories_helper_patch.rb
@@ -135,7 +135,7 @@ module ScmRepositoriesHelperPatch
                 gittags << hidden_field_tag(:operation, '', :id => 'repository_operation')
                 unless request.post?
                     path = GitCreator.access_root_url(GitCreator.default_path(@project.identifier), repository)
-                    if GitCreator.repository_exists?(@project.identifier)
+                    if GitCreator.repository_exists?(@project.identifier) or GitCreator.options['in_subdir']
                         offset = @project.repositories.select{ |r| r.created_with_scm }.size.to_s
                         
                         seperator = '.'

--- a/lib/scm_repositories_helper_patch.rb
+++ b/lib/scm_repositories_helper_patch.rb
@@ -137,8 +137,8 @@ module ScmRepositoriesHelperPatch
                     path = GitCreator.access_root_url(GitCreator.default_path(@project.identifier), repository)
                     if GitCreator.repository_exists?(@project.identifier)
                         offset = @project.repositories.select{ |r| r.created_with_scm }.size.to_s
-                        if path.sub!(%r{\.git\z}, '.' + offset + '.git').nil?
-                            path << '.' + offset
+                        if path.sub!(%r{\.git\z}, '/' + offset + '.git').nil?
+                            path << '/' + offset
                         end
                     end
                     gittags << javascript_tag("$('#repository_url').val('#{escape_javascript(path)}');")

--- a/lib/scm_repositories_helper_patch.rb
+++ b/lib/scm_repositories_helper_patch.rb
@@ -137,8 +137,14 @@ module ScmRepositoriesHelperPatch
                     path = GitCreator.access_root_url(GitCreator.default_path(@project.identifier), repository)
                     if GitCreator.repository_exists?(@project.identifier)
                         offset = @project.repositories.select{ |r| r.created_with_scm }.size.to_s
-                        if path.sub!(%r{\.git\z}, '/' + offset + '.git').nil?
-                            path << '/' + offset
+                        
+                        seperator = '.'
+                        if GitCreator.options['in_subdir']
+                            seperator = '/'
+                        end
+                        
+                        if path.sub!(%r{\.git\z}, seperator + offset + '.git').nil?
+                            path << seperator + offset
                         end
                     end
                     gittags << javascript_tag("$('#repository_url').val('#{escape_javascript(path)}');")


### PR DESCRIPTION
Some Redmine instructions tell you to create a structure like for proper authentication. This is also my setup. To be able to work with the scm-creator and old repos I added an config option "in_subdir" for git to allow for this setup.
It defaults to false, so no change to existing setups is needed.